### PR TITLE
PORT/seo: fix 1970 lastmod on project sitemap entries

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -50,9 +50,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     for (const project of projects) {
       const path = `/projects/${project.slug}`;
+      const projectDate = project.date ? new Date(project.date) : null;
+      const lastModified =
+        projectDate && projectDate.getTime() > 0 ? projectDate : now;
       entries.push({
         url: `${SITE_URL}/${lang}${path}`,
-        lastModified: new Date(project.date),
+        lastModified,
         changeFrequency: 'weekly',
         priority: 0.7,
         alternates: { languages: languageAlternates(path) },


### PR DESCRIPTION
  project.date is null in the DB, so new Date(project.date) returned the
  Unix epoch. Fall back to "now" when the date is missing or zero — the
  pages were genuinely last updated when the SEO pass shipped, and a fresh
  lastmod encourages Googlebot to re-crawl.

  Push that, then the sitemap will show real timestamps everywhere. When you're
  ready, either update project.date in Prisma Studio for accurate per-project
  history, or leave the fallback in place indefinitely.